### PR TITLE
Added facility to ensure we have route for exporters and reprocessors

### DIFF
--- a/EPRN.Portal/Constants/Constants.cs
+++ b/EPRN.Portal/Constants/Constants.cs
@@ -7,4 +7,10 @@ namespace EPRN.Portal.Constants
         public static readonly CultureInfo English = new CultureInfo("en-GB");
         public static readonly CultureInfo Welsh = new CultureInfo("cy-GB");
     }
+
+    public enum WasteType
+    {
+        Exporter,
+        Reprocessor
+    }
 }

--- a/EPRN.Portal/Helpers/WasteTypeConstraint.cs
+++ b/EPRN.Portal/Helpers/WasteTypeConstraint.cs
@@ -1,0 +1,31 @@
+﻿using EPRN.Portal.Constants;
+using System.Text.RegularExpressions;
+
+namespace EPRN.Portal.Helpers
+{
+    /// <summary>
+    /// This class ensures that when using waste type in a url
+    /// that it matches any of the possible values for a WasteType
+    /// (i.e. Exporter or Reprocessor
+    /// </summary>
+    public class WasteTypeConstraint : IRouteConstraint
+    {
+        public readonly string Pattern;
+
+        public WasteTypeConstraint()
+        {
+            // Generate a pattern based on your enumeration values
+            Pattern = string.Join("|", Enum.GetNames(typeof(WasteType)));
+        }
+
+        public bool Match(HttpContext httpContext, IRouter route, string routeKey, RouteValueDictionary values, RouteDirection routeDirection)
+        {
+            object typeValue;
+            if (values.TryGetValue(routeKey, out typeValue) && typeValue != null)
+            {
+                return Regex.IsMatch(typeValue.ToString(), Pattern, RegexOptions.IgnoreCase);
+            }
+            return false;
+        }
+    }
+}

--- a/EPRN.Portal/Helpers/WasteTypeFilterAttribute.cs
+++ b/EPRN.Portal/Helpers/WasteTypeFilterAttribute.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc;
+using EPRN.Portal.Controllers;
+using EPRN.Portal.Constants;
+
+namespace EPRN.Portal.Helpers
+{
+    /// <summary>
+    /// This class ensures that the member variable _wasteType
+    /// of the WasteController is populated with the correct value 
+    /// from the route provided in the url
+    /// </summary>
+    public class WasteTypeFilterAttribute : ActionFilterAttribute
+    {
+        public override void OnActionExecuting(ActionExecutingContext context)
+        {
+            if (context.RouteData.Values.TryGetValue("type", out var typeValue))
+            {
+                if (Enum.TryParse<WasteType>(typeValue.ToString(), ignoreCase: true, out WasteType wasteType))
+                {
+                    // Successfully parsed, set it as a parameter in the action method
+                    context.ActionArguments["type"] = wasteType;
+
+                    // Set it as a private member variable in the controller
+                    var controller = context.Controller as WasteController;
+                    controller._wasteType = wasteType;
+
+                    // Continue with the action execution
+                    base.OnActionExecuting(context);
+                }
+                else
+                {
+                    // Parsing failed, short-circuit the request and return BadRequest
+                    context.Result = new BadRequestObjectResult("Invalid WasteType value");
+                }
+            }
+        }
+    }
+}

--- a/EPRN.Portal/Program.cs
+++ b/EPRN.Portal/Program.cs
@@ -28,6 +28,11 @@ builder.Services
         opts.SupportedUICultures = supportedCultures;
     });
 
+builder.Services.Configure<RouteOptions>(options =>
+{
+    options.ConstraintMap.Add("WasteType", typeof(WasteTypeConstraint));
+});
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
@@ -40,9 +45,10 @@ else
     app.UseExceptionHandler("/Error/500");
     // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
     app.UseHsts();
+    app.UseStatusCodePagesWithReExecute("/Error/{0}");
 }
 
-app.UseStatusCodePagesWithReExecute("/Error/{0}");
+
 app.UseCultureMiddleware();
 app.UseRequestLocalization();
 app.UseHttpsRedirection();
@@ -50,7 +56,7 @@ app.UseStaticFiles();
 app.UseRouting();
 
 app.UseAuthorization();
-
+app.UseSession();
 
 app.MapControllerRoute(
     name: "areas",

--- a/EPRN.Portal/Views/Home/Index.cshtml
+++ b/EPRN.Portal/Views/Home/Index.cshtml
@@ -50,7 +50,7 @@
         {"card_description", @WasteJourneyResources.HomePage_WasteManagement_Description},
         {"card_links", new Dictionary<string, string>() {
         {
-            @WasteJourneyResources.HomePage_WasteManagement_Link_RecordWaste, Url.ActionLink("Types", "Waste")
+            @WasteJourneyResources.HomePage_WasteManagement_Link_RecordWaste, Url.Action("Types", "Waste", new { type = WasteType.Exporter })
         },
         {@WasteJourneyResources.HomePage_WasteManagement_Link_ManageAPrn, "#"},
         {@WasteJourneyResources.HomePage_WasteManagement_Link_SubmitAReturn, "#"},


### PR DESCRIPTION
Waste routes will now be of the form: 

~/Waste/Exporter/[Action]/[Id]
Or
~/Waste/Reprocessor/[Action]/[Id]

The type will be saved into the controller into the _wasteType variable which is an enum containing the two types we can have our waste defined as.

